### PR TITLE
Fix path names

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -82,10 +82,10 @@ include: snake_dir + 'bin/align/Snakefile'
 def which_all(wildcards):
     F = []
     # predictions
-    F += expand(af_dir + '{sample}/features.pkl',
+    F += expand(A(af_dir + '{sample}/features.pkl'),
                 sample = config['samples'].Sample)
     for i in range(5):
-        F += expand(af_dir + '{{sample}}/ranked_{}.pdb'.format(i),
+        F += expand(A(af_dir + '{{sample}}/ranked_{}.pdb'.format(i)),
                     sample = config['samples'].Sample)
     # alignents
     ## intra

--- a/bin/alphafold/Snakefile
+++ b/bin/alphafold/Snakefile
@@ -230,13 +230,13 @@ rule af_predict:
         mgf = af_dir + '{sample}/msas/mgnify_hits.sto',
         jsn = af_dir + '{sample}/msas/chain_id_map.json'
     output:
-        pkl = af_dir + '{sample}/features.pkl',
-        rnk0 = af_dir + '{sample}/ranked_0.pdb',
-        rnk1 = af_dir + '{sample}/ranked_1.pdb',
-        rnk2 = af_dir + '{sample}/ranked_2.pdb',
-        rnk3 = af_dir + '{sample}/ranked_3.pdb',
-        rnk4 = af_dir + '{sample}/ranked_4.pdb',
-        tim = af_dir + '{sample}/timings.json'
+        pkl = A(af_dir + '{sample}/features.pkl'),
+        rnk0 = A(af_dir + '{sample}/ranked_0.pdb'),
+        rnk1 = A(af_dir + '{sample}/ranked_1.pdb'),
+        rnk2 = A(af_dir + '{sample}/ranked_2.pdb'),
+        rnk3 = A(af_dir + '{sample}/ranked_3.pdb'),
+        rnk4 = A(af_dir + '{sample}/ranked_4.pdb'),
+        tim = A(af_dir + '{sample}/timings.json')
     params:
         exe = config['pipeline']['script_folder'] + 'alphafold/run_alphafold.py',
         sample = lambda wildcards : wildcards.sample,


### PR DESCRIPTION
Due to a mix of absolute and relative paths, the pipeline failed to run.
This commit corrects the problem.